### PR TITLE
update: Cast user and sender IDs to int in API responses

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -96,7 +96,7 @@ class AuthController extends Controller
 
         return Response::success(null, [
             'data' => [
-                'id' => $data->id,
+                'id' => (int) $data->id,
                 'name' => $data->name,
                 'username' => $data->username,
                 'email' => $data->email,

--- a/app/Http/Controllers/Api/ChatController.php
+++ b/app/Http/Controllers/Api/ChatController.php
@@ -30,7 +30,17 @@ class ChatController extends Controller
             ->limit(20)
             ->get()
             ->reverse()
-            ->values();
+            ->values()
+            ->map(function ($item) {
+                return [
+                    'id' => $item->id,
+                    'room_id' => $item->room_id,
+                    'sender_id' => (int) $item->sender_id,
+                    'type' => $item->type,
+                    'content' => $item->content,
+                    'sent_at' => $item->sent_at
+                ];
+            });
 
         return Response::success(null, ['chats' => $chats]);
     }
@@ -52,7 +62,7 @@ class ChatController extends Controller
             broadcast(new RoomEvent($request->room_id, [
                 'id' => $request->id,
                 'room_id' => $request->room_id,
-                'sender_id' => $request->user()->id,
+                'sender_id' => (int) $request->user()->id,
                 'type' => $request->type,
                 'content' => $request->content,
                 'sent_at' => $sentAt

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,10 +18,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
-
 Broadcast::routes(['middleware' => ['auth:sanctum']]);
 
 Route::prefix('/auth')->group(function () {


### PR DESCRIPTION
Ensures 'id' and 'sender_id' fields are explicitly cast to integers in AuthController and ChatController responses for consistency. Also removes an unused '/user' route from api.php.