### PR TITLE
update: Include sender_name in chat message payload

### DIFF
--- a/app/Http/Controllers/Api/ChatController.php
+++ b/app/Http/Controllers/Api/ChatController.php
@@ -63,6 +63,7 @@ class ChatController extends Controller
                 'id' => $request->id,
                 'room_id' => $request->room_id,
                 'sender_id' => (int) $request->user()->id,
+                'sender_name' => $request->user()->name,
                 'type' => $request->type,
                 'content' => $request->content,
                 'sent_at' => $sentAt


### PR DESCRIPTION
Added the sender's name to the chat message data returned by the sendText method. This provides clients with more user information for each message.